### PR TITLE
Fixed issue #19

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,10 +1,22 @@
 function minmax(value, min, max) 
 {
-    if(parseInt(value) < min || isNaN(parseInt(value))) 
-        return 4; 
-    else if(parseInt(value) > max) 
-        return 99; 
-    else return value;
+    if (value.indexOf('.') > -1)
+    {
+       if (value === ".") return; //We're only interested in whole numbers, so we'll disallow this.  A dot can't be in the first position.
+       return  value.split('.')[0];
+    }
+    if (value.length < 2) return value; //We can't yet be sure the number is less than min.
+
+    const parsedInput = parseInt(value);
+
+    if (parsedInput >= min && parsedInput <= max)
+        return value;
+    else if(parsedInput < min)
+        return min;
+
+    else if(parsedInput > max)
+        return max;
+    return value;
 }
 
 var passwordLength = document.getElementById("password-length");
@@ -20,12 +32,18 @@ var defaultCharacters = ["@", "%", "+", "'", "!", "#", "$", "^", "?", ":", ".", 
 var characters = [];
 var passwordArray = [];
 
+const MIN =4;
+const MAX = 99;
 
 function generatePassword() {
     randomPassword.innerHTML = "";
     passwordArray=[];
     characters = defaultCharacters;
-    if (!specialCharacters.checked) {
+    console.log(passwordLength.value);
+    console.log(minmax(passwordLength.value,MIN,MAX))
+    const pwLength = parseInt(passwordLength.value);
+
+        if (!specialCharacters.checked) {
         characters = characters.join("").replace(/[@%+'!#$^?:.~]/g,'').split('')
     } 
     if (!includeNumbers.checked) {
@@ -37,12 +55,21 @@ function generatePassword() {
     if (!ambiguousCharacters.checked) {
         characters = characters.join("").replace(/[1Ilo0]/g,'').split('')
     }
+
+    if (pwLength < MIN || pwLength > MAX) {//Final validation in case something is wrong.
+        errorMessage.innerHTML = "You must pick a password between " + MIN + " and " + MAX;
+        return;
+    }
+
+
     if (!specialCharacters.checked && !includeNumbers.checked && !includeLetters.checked) {
         errorMessage.innerHTML = "Alas, blank passwords aren't a thing yet."
+        return;
     }
     if (!repeatCharacters.checked) {
         if (passwordLength.value > characters.length) {
             errorMessage.innerHTML = "There are only so many characters, we're going to have to repeat something"
+            return;
         } else {
             while (passwordArray.length < passwordLength.value) {
                 var randomIndex = Math.floor(Math.random()*characters.length);
@@ -61,3 +88,6 @@ function generatePassword() {
     }
     randomPassword.innerHTML = passwordArray.join("");
 }
+
+function getMin() {return MIN;}
+function getMax () {return MAX;}


### PR DESCRIPTION
Fixed issue #19.  Password length text input works as expected and throws an error if it doesn't validate when generate password is clicked.  An `onblur` `minmax` call would also work if you'd prefer not to throw an error.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
